### PR TITLE
fix AppointmentController tests running in IntelliJ

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,13 +84,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jmockit</groupId>
-      <artifactId>jmockit</artifactId>
-      <version>1.49</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <version>5.7.1</version>
@@ -114,9 +107,6 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
         <configuration>
-          <argLine>
-            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/1.49/jmockit-1.49.jar
-          </argLine>
           <excludedGroups>integration</excludedGroups>
         </configuration>
       </plugin>
@@ -126,9 +116,6 @@
         <!--        <version>2.19.1</version>-->
         <version>3.0.0-M5</version>
         <configuration>
-          <argLine>
-            -javaagent:"${settings.localRepository}"/org/jmockit/jmockit/1.49/jmockit-1.49.jar
-          </argLine>
           <includes>
             <include>**/*.java</include>
           </includes>

--- a/src/test/java/com/sweng894/GetVaccinated/api/AppointmentControllerTest.java
+++ b/src/test/java/com/sweng894/GetVaccinated/api/AppointmentControllerTest.java
@@ -1,34 +1,22 @@
 package com.sweng894.GetVaccinated.api;
 
-import mockit.Expectations;
-import mockit.Injectable;
-import mockit.Mocked;
-import mockit.Tested;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Assertions;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import com.sweng894.GetVaccinated.api.controller.AppointmentController;
-import com.sweng894.GetVaccinated.api.repository.AppointmentRepository;
 import com.sweng894.GetVaccinated.api.entity.Appointment;
 
 @Tag("integration")
 @SpringBootTest
 public class AppointmentControllerTest {
-  @Tested
+  @Autowired
   private AppointmentController appointmentController;
-
-  @Injectable
-  AppointmentRepository repository;
 
   @Test
   public void testSaveAppointmentSuccess() {
-    new Expectations() {{
-      repository.save(getGenericAppointment());
-      result = getGenericAppointment();
-    }};
-
     Appointment expected = new Appointment(
       "David Sweeney",
       "TEST_CONFIRMATION_NUMBER",
@@ -37,40 +25,14 @@ public class AppointmentControllerTest {
       "2021-04-09 21:00:00"
     );
 
-    expected = appointmentController.saveAppointment(expected);
-    Assertions.assertEquals(expected.getConfirmationNumber(),
-      appointmentController.saveAppointment(expected).getConfirmationNumber());
-  }
-
-  @Test
-  public void testGetAppointmentConfirmationSuccess() {
-    new Expectations(){{
-      repository.getAppointmentConfirmation("TEST_CONFIRMATION_NUMBER",
-        "test@abc.com");
-      result = getGenericAppointment();
-    }};
-
-    Appointment expected = new Appointment(
-      "David Sweeney",
-      "TEST_CONFIRMATION_NUMBER",
-      "test@abc.com",
-      "CONFIRMED",
-      "2021-04-09 21:00:00"
-    );
-
-    Assertions.assertEquals(expected.getConfirmationNumber(),
-      appointmentController.getAppointmentConfirmation(expected.getConfirmationNumber(),
-        expected.getEmail()).getConfirmationNumber());
+    appointmentController.saveAppointment(expected);
+    var expectedConfirmation = expected.getConfirmationNumber();
+    var actualConfirmation = appointmentController.getAppointmentConfirmation(expectedConfirmation, expected.getEmail()).getConfirmationNumber();
+    Assertions.assertEquals(expectedConfirmation, actualConfirmation);
   }
 
   @Test
   public void testDeleteAppointmentSuccess() {
-    new Expectations(){{
-      repository.delete("TEST_CONFIRMATION_NUMBER",
-        "test@abc.com");
-      result = "Appointment Cancelled!";
-    }};
-
     Appointment expected = new Appointment(
       "David Sweeney",
       "TEST_CONFIRMATION_NUMBER",
@@ -86,17 +48,13 @@ public class AppointmentControllerTest {
 
   @Test
   public void testUpdateAppointmentSuccess() {
-    Appointment actual = new Appointment(
+    appointmentController.saveAppointment(new Appointment(
       "David Sweeney",
       "TEST_CONFIRMATION_NUMBER",
       "test@abc.com",
       "CONFIRMED",
       "2021-04-09 21:00:00"
-    );
-    new Expectations(){{
-      repository.update("TEST_CONFIRMATION_NUMBER", actual);
-      result = "Appointment Cancelled!";
-    }};
+    ));
 
     Appointment expected = new Appointment(
       "David Sweeney",
@@ -106,7 +64,7 @@ public class AppointmentControllerTest {
       "2021-04-09 21:00:00"
     );
 
-    Assertions.assertEquals("Appointment Cancelled!",
+    Assertions.assertEquals("TEST_CONFIRMATION_NUMBER",
       appointmentController.updateAppointment(expected.getConfirmationNumber(),
         expected));
   }

--- a/src/test/java/com/sweng894/GetVaccinated/api/GeocodeAPITests.java
+++ b/src/test/java/com/sweng894/GetVaccinated/api/GeocodeAPITests.java
@@ -4,9 +4,11 @@ import com.sweng894.GetVaccinated.api.library.GeocodeAPI;
 import net.bytebuddy.description.type.TypeList;
 import net.minidev.json.JSONObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
+@Tag("integration")
 @SpringBootTest
 public class GeocodeAPITests {
 

--- a/src/test/java/com/sweng894/GetVaccinated/api/GeohashTests.java
+++ b/src/test/java/com/sweng894/GetVaccinated/api/GeohashTests.java
@@ -8,7 +8,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.util.HashMap;
 import java.util.Map;
 
-@SpringBootTest
 public class GeohashTests {
 
   @Test


### PR DESCRIPTION
The tests were modified to use an actual Appointment repository instead
of a mocked one. jmockit was removed as a dependency.